### PR TITLE
fix env key in doc

### DIFF
--- a/docs/configuration/configuration.md
+++ b/docs/configuration/configuration.md
@@ -40,7 +40,7 @@ By default, the config will be read from environment variables and/or `.env` fil
 
 > Used by Dispatch's authentication backend to pull the JSON Web Key Set \(JWKS\) public key from our specified provider. The result of this URL is cached for up to 1 hour.
 
-#### `VUE_APP_DISPATCH_OPEN_ID_CONNECT`
+#### `VUE_APP_DISPATCH_OPEN_ID_CONNECT_URL`
 
 > Used by the Dispatch Web UI send the user via Proof Key Code Exchange \(PKCE\) to a correct open id connect endpoint.
 


### PR DESCRIPTION
Environment variable VUE_APP_DISPATCH_OPEN_ID_CONNECT_URL is used in the vue app, not VUE_APP_DISPATCH_OPEN_ID_CONNECT.